### PR TITLE
Fix/title encode

### DIFF
--- a/pages/api/proxy.ts
+++ b/pages/api/proxy.ts
@@ -12,9 +12,19 @@ const proxyApi = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   const response = await fetch(url);
-  const text = await response.text();
+
+  // 文字コード取得
+  const arrayBuffer = await response.arrayBuffer();
+  let decode_text = new TextDecoder().decode(arrayBuffer);
+  const charset = decode_text.match(/<meta[^>]+charset=["']?([^"'>\s]+)/i);
+  if (charset && charset[1] !== "utf-8") {
+    const decoder = new TextDecoder(charset[1]);
+    decode_text = decoder.decode(arrayBuffer);
+  }
+
+  //const text = await response.text();
   res.setHeader("Content-Type", "text/html");
-  res.status(200).send(text);
+  res.status(200).send(decode_text);
 };
 
 export default proxyApi;

--- a/pages/api/proxy.ts
+++ b/pages/api/proxy.ts
@@ -13,7 +13,7 @@ const proxyApi = async (req: NextApiRequest, res: NextApiResponse) => {
 
   const response = await fetch(url);
 
-  // 文字コード取得
+  // 文字コード取得とデコード
   const arrayBuffer = await response.arrayBuffer();
   let decode_text = new TextDecoder().decode(arrayBuffer);
   const charset = decode_text.match(/<meta[^>]+charset=["']?([^"'>\s]+)/i);
@@ -22,7 +22,6 @@ const proxyApi = async (req: NextApiRequest, res: NextApiResponse) => {
     decode_text = decoder.decode(arrayBuffer);
   }
 
-  //const text = await response.text();
   res.setHeader("Content-Type", "text/html");
   res.status(200).send(decode_text);
 };


### PR DESCRIPTION
タイトルの文字化けに対応しました。

原因：該当サイトの文字コードがUTF-8以外の時に発生。
対処：APIに作成したプロキシサーバでHTMLをデコード後、charsetを取得しUTF-8以外であればcharsetに合わせたデコードをして返却、という流れに変換